### PR TITLE
Fix: set response code before JSON output in Switchboard

### DIFF
--- a/src/Bootstrap/Switchboard/Switchboard.php
+++ b/src/Bootstrap/Switchboard/Switchboard.php
@@ -82,12 +82,12 @@ abstract class Switchboard extends FunctionHelper
         $use_class = $this->findMasterClass();
         if ($use_class === null) {
             $this->addError("Unsupported request");
+            http_response_code(501);
             print json_encode([
                 "status" => false,
                 "message" => "[" . $this->loadingModule . " | "
                     . $this->loadingArea . " | " . $this->config->getPage() . "] Unsupported",
             ]);
-            http_response_code(501);
             return;
         }
 


### PR DESCRIPTION
Move the 501 status before JSON output.
This prevents PHP from trying to modify headers after output has already started, which caused the warning in logs.